### PR TITLE
qtvirtualkeyboard: add patch only reparent the InputPanel when necessary

### DIFF
--- a/recipes-qt/qt5/qtvirtualkeyboard/0002-Only-reparent-the-InputPanel.patch
+++ b/recipes-qt/qt5/qtvirtualkeyboard/0002-Only-reparent-the-InputPanel.patch
@@ -1,0 +1,96 @@
+
+From f5705aab45a55acf092f012a7339144e98deace4 Mon Sep 17 00:00:00 2001
+From: Volker Hilsheimer <volker.hilsheimer@qt.io>
+Date: Sat, 16 Oct 2021 10:37:13 +0200
+Subject: Only reparent the InputPanel when necessary
+
+The input panel needs to work also while a modal popup is open. Since
+the concept of modality does not exist in Qt Quick, and is implemented
+with an event-eating overlay, 4e8b3dd45ae4cc66a1b77cce901f80406b2a0f69
+introduced the automatic reparenting of the integrated input panel so
+that it a sibling of the overlay, with a higher z-value.
+
+This effectively changed the parent item, and had negative side effects
+to mechanisms such as anchoring.
+
+This change only reparents the input panel if there is an overlay (using
+the mechanism also used by the Qt Quick Control class QQuickOverlay)
+that is visible when the input item changes, and sets the z-value to be
+one above the overlay's. The prevents modal blocking during the overlay
+session. When the input item changes again and the overlay is no longer
+visible, then the parent and z value get reset.
+
+This improves the situation, but is still not ideal, as during modal
+sessions the anchoring of the input panel will still not work as
+expected.
+
+Add a test case that verifies that clicks go through to the keyboard
+while a modal dialog is open.
+
+Fixes: QTBUG-97075
+Task-number: QTBUG-56918
+Task-number: QTBUG-92881
+Change-Id: I7a5bcfebe7b69780234737a2311e08b2a6f60a4e
+Reviewed-by: Jarkko Koivikko <jarkko.koivikko@code-q.fi>
+(cherry picked from commit 5564f1c96322d7c3f884d2e6f9b3a95e3134fb9f)
+Reviewed-by: Mitch Curtis <mitch.curtis@qt.io>
+---
+ .../qvirtualkeyboardinputcontext_p.cpp              | 21 +++++++++++++++++----
+ .../qvirtualkeyboardinputcontext_p.h                |  2 ++
+ 2 files changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.cpp b/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.cpp
+index 028f3f71..645a6310 100644
+--- a/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.cpp
++++ b/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.cpp
+@@ -220,8 +220,6 @@ void QVirtualKeyboardInputContextPrivate::registerInputPanel(QObject *inputPanel
+     VIRTUALKEYBOARD_DEBUG() << "QVirtualKeyboardInputContextPrivate::registerInputPanel():" << inputPanel;
+     Q_ASSERT(!this->inputPanel);
+     this->inputPanel = inputPanel;
+-    if (QQuickItem *item = qobject_cast<QQuickItem *>(inputPanel))
+-        item->setZ(std::numeric_limits<qreal>::max());
+ }
+ 
+ void QVirtualKeyboardInputContextPrivate::hideInputPanel()
+@@ -279,8 +277,23 @@ void QVirtualKeyboardInputContextPrivate::onInputItemChanged()
+                     high z-order will make sure it gets events also during a modal session.
+                 */
+                 if (isDesktopPanel.isValid() && !isDesktopPanel.toBool()) {
+-                    if (QQuickWindow *quickWindow = quickItem->window())
+-                        vkbPanel->setParentItem(quickWindow->contentItem());
++                    if (QQuickWindow *quickWindow = quickItem->window()) {
++                        QQuickItem *overlay = quickWindow->property("_q_QQuickOverlay").value<QQuickItem*>();
++                        if (overlay && overlay->isVisible()) {
++                            if (vkbPanel->parentItem() != overlay->parentItem()) {
++                                inputPanelParentItem = vkbPanel->parentItem();
++                                inputPanelZ = vkbPanel->z();
++                                vkbPanel->setParentItem(overlay->parentItem());
++                                vkbPanel->setZ(overlay->z() + 1);
++                            }
++                        } else {
++                            if (QQuickItem *oldParentItem = qobject_cast<QQuickItem *>(inputPanelParentItem.data())) {
++                                vkbPanel->setParentItem(oldParentItem);
++                                vkbPanel->setZ(inputPanelZ);
++                                inputPanelParentItem = nullptr;
++                            }
++                        }
++                    }
+                 }
+             }
+         }
+diff --git a/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.h b/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.h
+index c614a4b1..941fb3ed 100644
+--- a/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.h
++++ b/src/virtualkeyboard/qvirtualkeyboardinputcontext_p.h
+@@ -153,6 +153,8 @@ private:
+     QVirtualKeyboardInputEngine *inputEngine;
+     QtVirtualKeyboard::ShiftHandler *_shiftHandler;
+     QPointer<QObject> inputPanel;
++    QPointer<QObject> inputPanelParentItem;
++    qreal inputPanelZ = .0;
+     QRectF keyboardRect;
+     QRectF previewRect;
+     bool _previewVisible;
+-- 
+cgit v1.2.3
+

--- a/recipes-qt/qt5/qtvirtualkeyboard_%.bbappend
+++ b/recipes-qt/qt5/qtvirtualkeyboard_%.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-broken-character-being-inserted-on-wayland.patch"
+SRC_URI += " \
+    file://0001-broken-character-being-inserted-on-wayland.patch \
+    file://0002-Only-reparent-the-InputPanel.patch \
+"


### PR DESCRIPTION
Backport Qt patch from Qt 5.15.9 due to the keyboard not being able to rotate correctly with the screen


thx to @basyskom-broulik