### PR TITLE
added template for gallium hud as comment

### DIFF
--- a/recipes-core/embedded-compositor/files/embedded-compositor.service
+++ b/recipes-core/embedded-compositor/files/embedded-compositor.service
@@ -8,9 +8,14 @@ RequiresMountsFor=/run
 Type=simple
 EnvironmentFile=/etc/default/embedded-compositor/xdg-path
 EnvironmentFile=/etc/default/embedded-compositor/screen-orientation
-# nedded for i.MX6-GPUs
+
+# Needed for i.MX6 GPUs, see documentation: https://doc.qt.io/qt-6/qtwaylandcompositor-attribution-wayland-linux-dmabuf-unstable-v1.html
 #Environment="QT_WAYLAND_CLIENT_BUFFER_INTEGRATION=linux-dmabuf-unstable-v1"
 Environment="QT_QPA_PLATFORM=eglfs"
+
+# For more information, see documentation: https://docs.mesa3d.org/envvars.html
+#Environment="GALLIUM_HUD=fps"
+
 RuntimeDirectory=user/0
 RuntimeDirectoryPreserve=yes
 ExecStart=/usr/bin/embedded-compositor


### PR DESCRIPTION
add comment as a suggestion for the mesa GALLIUM environment variables. This environment variable activate the fps hud. Include references to external documentation for better understanding of the configuration settings.