### PR TITLE
QTBUG-97086: added patch for the Workaround broken character being inserted on Wayland

### DIFF
--- a/recipes-qt/qt6/qtvirtualkeyboard/0001-broken-character-being-inserted-on-wayland.patch
+++ b/recipes-qt/qt6/qtvirtualkeyboard/0001-broken-character-being-inserted-on-wayland.patch
@@ -1,0 +1,34 @@
+From 0afa66634017ac64ef991de1777c347fb2c74a4a Mon Sep 17 00:00:00 2001
+From: Kai Uwe Broulik <kai.uwe.broulik@basyskom.com>
+Date: Wed, 30 Oct 2024 14:28:44 +0100
+Subject: [PATCH] Workaround broken character being inserted on Wayland
+
+The SymbolModeKey sends Qt::Key_Context1 which ends up
+producing an invalid U+10000 character in the text field.
+
+Task-number: QTBUG-97086
+Change-Id: I1484eff13ea6e5c0f980ae2ff1287f8c11925dbb
+---
+ src/virtualkeyboard/qvirtualkeyboardinputengine.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/virtualkeyboard/qvirtualkeyboardinputengine.cpp b/src/virtualkeyboard/qvirtualkeyboardinputengine.cpp
+index 5f74c2a7..0d5b5e03 100644
+--- a/src/virtualkeyboard/qvirtualkeyboardinputengine.cpp
++++ b/src/virtualkeyboard/qvirtualkeyboardinputengine.cpp
+@@ -69,6 +69,12 @@ public:
+     bool virtualKeyClick(Qt::Key key, const QString &text, Qt::KeyboardModifiers modifiers, bool isAutoRepeat)
+     {
+         Q_Q(QVirtualKeyboardInputEngine);
++
++        // HACK QTBUG-97086: SymbolModeKey causes broken character to be inserted.
++        if (key == Qt::Key_Context1) {
++            return true;
++        }
++
+         bool accept = false;
+         if (inputMethod) {
+             accept = inputMethod->keyEvent(key, text, modifiers);
+-- 
+2.43.0
+

--- a/recipes-qt/qt6/qtvirtualkeyboard_%.bbappend
+++ b/recipes-qt/qt6/qtvirtualkeyboard_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://0001-broken-character-being-inserted-on-wayland.patch \
+"


### PR DESCRIPTION
The SymbolModeKey sends Qt::Key_Context1 which ends up producing an invalid U+10000 character in the text field.